### PR TITLE
Enable CI on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 os:
   - linux
-  - osx
 python:
   - 2.7
   - 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,13 @@ os:
   - linux
   - osx
 python:
+  - 2.7
+  - 3.3
+  - 3.4
   - 3.5
 sudo: false
 env:
-  fast_finish: true
-  matrix:
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py34
-    - TOXENV=py35
+  - TOXENV="py${PYTHON_VERSION//./}"
 install:
   - pip install tox coveralls
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+os:
+  - linux
+  - osx
 python:
   - 3.5
 sudo: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Gitter](https://img.shields.io/gitter/room/frictionlessdata/chat.svg)](https://gitter.im/frictionlessdata/chat)
 [![Build Status](https://travis-ci.org/frictionlessdata/datapackage-py.svg?branch=master)](https://travis-ci.org/frictionlessdata/datapackage-py)
+[![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/frictionlessdata/datapackage-py?branch=master&svg=true)](https://ci.appveyor.com/project/vitorbaptista/datapackage-py)
 [![Test Coverage](https://coveralls.io/repos/frictionlessdata/datapackage-py/badge.svg?branch=master&service=github)](https://coveralls.io/github/frictionlessdata/datapackage-py)
 ![Support Python versions 2.7, 3.3, 3.4 and 3.5](https://img.shields.io/badge/python-2.7%2C%203.3%2C%203.4%2C%203.5-blue.svg)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,5 +8,7 @@ environment:
 install:
   - '%PYTHON%\\python.exe -m pip install tox'
 
+build: off
+
 test_script:
   - '%PYTHON%\\scripts\\tox'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+environment:
+  matrix:
+    - PYTHON: 'C:\\Python27'
+    - PYTHON: 'C:\\Python33'
+    - PYTHON: 'C:\\Python34'
+    - PYTHON: 'C:\\Python35'
+
+install:
+  - '%PYTHON%\\python.exe -m pip install tox'
+
+test_script:
+  - '%PYTHON%\\scripts\\tox'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,13 @@
 environment:
   matrix:
     - PYTHON: 'C:\\Python27'
+      TOXENV: 'py27'
     - PYTHON: 'C:\\Python33'
+      TOXENV: 'py33'
     - PYTHON: 'C:\\Python34'
+      TOXENV: 'py34'
     - PYTHON: 'C:\\Python35'
+      TOXENV: 'py35'
 
 install:
   - '%PYTHON%\\python.exe -m pip install tox'


### PR DESCRIPTION
Originally I wanted to enable CI on OSX as well, but Travis doesn't support Python + OSX out of the box. (see https://github.com/travis-ci/travis-ci/issues/2312). There're workarounds, which I think we should do later (issue #61), but I didn't want to spend more time on this issue now. This fixes #60.