### PR TITLE
Return storage object after push/pull

### DIFF
--- a/datapackage/pushpull.py
+++ b/datapackage/pushpull.py
@@ -75,6 +75,7 @@ def push_datapackage(descriptor, backend, **backend_options):
     for table in storage.tables:
         if table in datamap:
             storage.write(table, datamap[table])
+    return storage
 
 
 def pull_datapackage(descriptor, name, backend, **backend_options):
@@ -139,3 +140,4 @@ def pull_datapackage(descriptor, name, backend, **backend_options):
             'resources': resources,
         }
         json.dump(descriptor, file, indent=4)
+    return storage


### PR DESCRIPTION
Some engines like [Python Pandas](https://github.com/frictionlessdata/jsontableschema-pandas-py) keeps data in memory and uses Storage as a container for data stored in memory.
    
In order to access that data, storage instance has to be returned.
    
See: https://github.com/frictionlessdata/datapackage-py/issues/73