### PR TITLE
Use descriptor, not metadata, to stay close to spec semantics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 A model for working with [Data Packages].
 
   [Data Packages]: http://dataprotocols.org/data-packages/
-  
+
 ## Install
 
 ```
@@ -63,16 +63,16 @@ except datapackage.exceptions.ValidationError as e:
 ```python
 import datapackage
 
-# This metadata has two errors:
+# This descriptor has two errors:
 #   * It has no "name", which is required;
 #   * Its resource has no "data", "path" or "url".
-metadata = {
+descriptor = {
     'resources': [
         {},
     ]
 }
 
-dp = datapackage.DataPackage(metadata)
+dp = datapackage.DataPackage(descriptor)
 
 for error in dp.iter_errors():
     # Handle error
@@ -84,13 +84,13 @@ for error in dp.iter_errors():
 import datapackage
 
 dp = datapackage.DataPackage()
-dp.metadata['name'] = 'my_sleep_duration'
-dp.metadata['resources'] = [
+dp.descriptor['name'] = 'my_sleep_duration'
+dp.descriptor['resources'] = [
     {'name': 'data'}
 ]
 
 resource = dp.resources[0]
-resource.metadata['data'] = [
+resource.descriptor['data'] = [
     7, 8, 5, 6, 9, 7, 8
 ]
 
@@ -110,10 +110,10 @@ import datapackage.registry
 registry_url = datapackage.registry.Registry.DEFAULT_REGISTRY_URL
 registry = datapackage.registry.Registry(registry_url)
 
-metadata = {}  # The datapackage.json file
+descriptor = {}  # The datapackage.json file
 schema = registry.get('tabular')  # Change to your schema ID
 
-dp = datapackage.DataPackage(metadata, schema)
+dp = datapackage.DataPackage(descriptor, schema)
 ```
 
 ### Push/pull Data Package to storage

--- a/datapackage/pushpull.py
+++ b/datapackage/pushpull.py
@@ -47,9 +47,9 @@ def push_datapackage(descriptor, backend, **backend_options):
 
     # Collect tables/schemas/data
     for resource in model.resources:
-        name = resource.metadata.get('name', None)
-        table = mappers.convert_path(resource.metadata['path'], name)
-        schema = resource.metadata['schema']
+        name = resource.descriptor.get('name', None)
+        table = mappers.convert_path(resource.descriptor['path'], name)
+        schema = resource.descriptor['schema']
         data = resource.iter()
         # TODO: review
         def values(schema, data):

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -27,24 +27,24 @@ class TestDataPackage(object):
         assert dp.schema.title == 'Data Package'
 
     def test_init_accepts_dicts(self):
-        metadata = {
+        descriptor = {
             'foo': 'bar',
         }
-        dp = datapackage.DataPackage(metadata)
-        assert dp.metadata == metadata
+        dp = datapackage.DataPackage(descriptor)
+        assert dp.descriptor == descriptor
 
     def test_init_accepts_filelike_object(self):
-        metadata = {
+        descriptor = {
             'foo': 'bar',
         }
-        filelike_metadata = six.StringIO(json.dumps(metadata))
-        dp = datapackage.DataPackage(filelike_metadata)
-        assert dp.metadata == metadata
+        filelike_descriptor = six.StringIO(json.dumps(descriptor))
+        dp = datapackage.DataPackage(filelike_descriptor)
+        assert dp.descriptor == descriptor
 
     def test_init_accepts_file_paths(self):
         path = test_helpers.fixture_path('empty_datapackage.json')
         dp = datapackage.DataPackage(path)
-        assert dp.metadata == {}
+        assert dp.descriptor == {}
 
     def test_init_raises_if_file_path_doesnt_exist(self):
         path = 'this-file-doesnt-exist.json'
@@ -76,7 +76,7 @@ class TestDataPackage(object):
                                content_type='application/json')
 
         dp = datapackage.DataPackage(url)
-        assert dp.metadata == {'foo': 'bar'}
+        assert dp.descriptor == {'foo': 'bar'}
 
     @httpretty.activate
     def test_init_raises_if_url_doesnt_exist(self):
@@ -106,15 +106,15 @@ class TestDataPackage(object):
         with pytest.raises(datapackage.exceptions.DataPackageException):
             datapackage.DataPackage(url)
 
-    def test_init_raises_if_metadata_isnt_dict_or_string(self):
-        metadata = 51
+    def test_init_raises_if_descriptor_isnt_dict_or_string(self):
+        descriptor = 51
         with pytest.raises(datapackage.exceptions.DataPackageException):
-            datapackage.DataPackage(metadata)
+            datapackage.DataPackage(descriptor)
 
     def test_schema(self):
-        metadata = {}
+        descriptor = {}
         schema = {'foo': 'bar'}
-        dp = datapackage.DataPackage(metadata, schema=schema)
+        dp = datapackage.DataPackage(descriptor, schema=schema)
         assert dp.schema.to_dict() == schema
 
     @mock.patch('datapackage.registry.Registry')
@@ -135,7 +135,7 @@ class TestDataPackage(object):
             datapackage.DataPackage()
 
     def test_attributes(self):
-        metadata = {
+        descriptor = {
             'name': 'test',
             'title': 'a test',
         }
@@ -144,33 +144,33 @@ class TestDataPackage(object):
                 'name': {}
             }
         }
-        dp = datapackage.DataPackage(metadata, schema)
+        dp = datapackage.DataPackage(descriptor, schema)
         assert sorted(dp.attributes) == sorted(['name', 'title'])
 
     def test_attributes_can_be_set(self):
-        metadata = {
+        descriptor = {
             'name': 'foo',
         }
-        dp = datapackage.DataPackage(metadata)
-        dp.metadata['title'] = 'bar'
+        dp = datapackage.DataPackage(descriptor)
+        dp.descriptor['title'] = 'bar'
         assert dp.to_dict() == {'name': 'foo', 'title': 'bar'}
 
     def test_attributes_arent_immutable(self):
-        metadata = {
+        descriptor = {
             'keywords': [],
         }
-        dp = datapackage.DataPackage(metadata)
-        dp.metadata['keywords'].append('foo')
+        dp = datapackage.DataPackage(descriptor)
+        dp.descriptor['keywords'].append('foo')
         assert dp.to_dict() == {'keywords': ['foo']}
 
     def test_attributes_return_an_empty_tuple_if_there_are_none(self):
-        metadata = {}
+        descriptor = {}
         schema = {}
-        dp = datapackage.DataPackage(metadata, schema)
+        dp = datapackage.DataPackage(descriptor, schema)
         assert dp.attributes == ()
 
     def test_validate(self):
-        metadata = {
+        descriptor = {
             'name': 'foo',
         }
         schema = {
@@ -179,7 +179,7 @@ class TestDataPackage(object):
             },
             'required': ['name'],
         }
-        dp = datapackage.DataPackage(metadata, schema)
+        dp = datapackage.DataPackage(descriptor, schema)
         dp.validate()
 
     def test_validate_works_when_setting_attributes_after_creation(self):
@@ -190,7 +190,7 @@ class TestDataPackage(object):
             'required': ['name'],
         }
         dp = datapackage.DataPackage(schema=schema)
-        dp.metadata['name'] = 'foo'
+        dp.descriptor['name'] = 'foo'
         dp.validate()
 
     def test_validate_raises_validation_error_if_invalid(self):
@@ -210,8 +210,8 @@ class TestDataPackage(object):
         iter_errors_mock.return_value = 'the iter errors'
         schema_mock.return_value.iter_errors = iter_errors_mock
 
-        metadata = {}
-        dp = datapackage.DataPackage(metadata)
+        descriptor = {}
+        dp = datapackage.DataPackage(descriptor)
 
         assert dp.iter_errors() == 'the iter errors'
         iter_errors_mock.assert_called_with(dp.to_dict())
@@ -229,18 +229,18 @@ class TestDataPackage(object):
         assert dp.required_attributes == ()
 
     def test_to_dict_value_can_be_altered_without_changing_the_dp(self):
-        metadata = {}
-        dp = datapackage.DataPackage(metadata)
+        descriptor = {}
+        dp = datapackage.DataPackage(descriptor)
         dp_dict = dp.to_dict()
         dp_dict['foo'] = 'bar'
-        assert dp.metadata == {}
+        assert dp.descriptor == {}
 
     def test_to_json(self):
-        metadata = {
+        descriptor = {
             'foo': 'bar',
         }
-        dp = datapackage.DataPackage(metadata)
-        assert json.loads(dp.to_json()) == metadata
+        dp = datapackage.DataPackage(descriptor)
+        assert json.loads(dp.to_json()) == descriptor
 
 
 class TestDataPackageResources(object):
@@ -268,36 +268,36 @@ class TestDataPackageResources(object):
         assert dp.base_path == base_url
 
     def test_resources_are_empty_tuple_by_default(self):
-        metadata = {}
-        dp = datapackage.DataPackage(metadata)
+        descriptor = {}
+        dp = datapackage.DataPackage(descriptor)
         assert dp.resources == ()
 
     def test_cant_assign_to_resources(self):
-        metadata = {}
-        dp = datapackage.DataPackage(metadata)
+        descriptor = {}
+        dp = datapackage.DataPackage(descriptor)
         with pytest.raises(AttributeError):
             dp.resources = ()
 
     def test_inline_resources_are_loaded(self):
-        metadata = {
+        descriptor = {
             'resources': [
                 {'data': 'foo'},
                 {'data': 'bar'},
             ],
         }
-        dp = datapackage.DataPackage(metadata)
+        dp = datapackage.DataPackage(descriptor)
         assert len(dp.resources) == 2
         assert dp.resources[0].data == 'foo'
         assert dp.resources[1].data == 'bar'
 
     def test_local_resource_with_absolute_path_is_loaded(self):
         path = test_helpers.fixture_path('foo.txt')
-        metadata = {
+        descriptor = {
             'resources': [
                 {'path': path},
             ],
         }
-        dp = datapackage.DataPackage(metadata)
+        dp = datapackage.DataPackage(descriptor)
         assert len(dp.resources) == 1
         assert dp.resources[0].data == b'foo\n'
 
@@ -309,26 +309,26 @@ class TestDataPackageResources(object):
         assert dp.resources[0].data == b'foo\n'
 
     def test_raises_if_local_resource_path_doesnt_exist(self):
-        metadata = {
+        descriptor = {
             'resources': [
                 {'path': 'inexistent-file.json'},
             ],
         }
 
         with pytest.raises(IOError):
-            datapackage.DataPackage(metadata).resources[0].data
+            datapackage.DataPackage(descriptor).resources[0].data
 
     @httpretty.activate
     def test_remote_resource_is_loaded(self):
         url = 'http://someplace.com/resource.txt'
         httpretty.register_uri(httpretty.GET, url, body='foo')
-        metadata = {
+        descriptor = {
             'resources': [
                 {'url': url},
             ],
         }
 
-        dp = datapackage.DataPackage(metadata)
+        dp = datapackage.DataPackage(descriptor)
         assert len(dp.resources) == 1
         assert dp.resources[0].data == b'foo'
 
@@ -336,17 +336,17 @@ class TestDataPackageResources(object):
     def test_raises_if_remote_resource_url_doesnt_exist(self):
         url = 'http://someplace.com/inexistent-file.json'
         httpretty.register_uri(httpretty.GET, url, status=404)
-        metadata = {
+        descriptor = {
             'resources': [
                 {'url': url},
             ],
         }
 
         with pytest.raises(IOError):
-            datapackage.DataPackage(metadata).resources[0].data
+            datapackage.DataPackage(descriptor).resources[0].data
 
-    def test_changing_resource_metadata_changes_it_in_the_datapackage(self):
-        metadata = {
+    def test_changing_resource_descriptor_changes_it_in_the_datapackage(self):
+        descriptor = {
             'resources': [
                 {
                     'data': '万事开头难',
@@ -354,8 +354,8 @@ class TestDataPackageResources(object):
             ]
         }
 
-        dp = datapackage.DataPackage(metadata)
-        dp.resources[0].metadata['name'] = 'saying'
+        dp = datapackage.DataPackage(descriptor)
+        dp.resources[0].descriptor['name'] = 'saying'
         assert dp.to_dict()['resources'][0]['name'] == 'saying'
 
     def test_can_add_resource(self):
@@ -363,22 +363,22 @@ class TestDataPackageResources(object):
             'data': '万事开头难',
         }
         dp = datapackage.DataPackage()
-        resources = dp.metadata.get('resources', [])
+        resources = dp.descriptor.get('resources', [])
         resources.append(resource)
-        dp.metadata['resources'] = resources
+        dp.descriptor['resources'] = resources
 
         assert len(dp.resources) == 1
         assert dp.resources[0].data == '万事开头难'
 
     def test_can_remove_resource(self):
-        metadata = {
+        descriptor = {
             'resources': [
                 {'data': '万事开头难'},
                 {'data': 'All beginnings are hard'}
             ]
         }
-        dp = datapackage.DataPackage(metadata)
-        del dp.metadata['resources'][1]
+        dp = datapackage.DataPackage(descriptor)
+        del dp.descriptor['resources'][1]
 
         assert len(dp.resources) == 1
         assert dp.resources[0].data == '万事开头难'
@@ -396,14 +396,14 @@ class TestSavingDataPackages(object):
         assert zipfile.is_zipfile(tmpfile.name)
 
     def test_adds_datapackage_descriptor_at_zipfile_root(self, tmpfile):
-        metadata = {
+        descriptor = {
             'name': 'proverbs',
             'resources': [
                 {'data': '万事开头难'}
             ]
         }
         schema = {}
-        dp = datapackage.DataPackage(metadata, schema)
+        dp = datapackage.DataPackage(descriptor, schema)
         dp.save(tmpfile)
         with zipfile.ZipFile(tmpfile, 'r') as z:
             dp_json = z.read('datapackage.json').decode('utf-8')
@@ -411,7 +411,7 @@ class TestSavingDataPackages(object):
 
     def test_generates_filenames_for_named_resources(self, tmpfile):
         resource_path = test_helpers.fixture_path('unicode.txt')
-        metadata = {
+        descriptor = {
             'name': 'proverbs',
             'resources': [
                 {'name': 'proverbs', 'format': 'TXT', 'path': resource_path},
@@ -419,14 +419,14 @@ class TestSavingDataPackages(object):
             ]
         }
         schema = {}
-        dp = datapackage.DataPackage(metadata, schema)
+        dp = datapackage.DataPackage(descriptor, schema)
         dp.save(tmpfile)
         with zipfile.ZipFile(tmpfile, 'r') as z:
             assert 'data/proverbs.txt' in z.namelist()
             assert 'data/proverbs_without_format' in z.namelist()
 
     def test_generates_unique_filenames_for_unnamed_resources(self, tmpfile):
-        metadata = {
+        descriptor = {
             'name': 'proverbs',
             'resources': [
                 {'path': test_helpers.fixture_path('unicode.txt')},
@@ -434,7 +434,7 @@ class TestSavingDataPackages(object):
             ]
         }
         schema = {}
-        dp = datapackage.DataPackage(metadata, schema)
+        dp = datapackage.DataPackage(descriptor, schema)
         dp.save(tmpfile)
         with zipfile.ZipFile(tmpfile, 'r') as z:
             files = z.namelist()
@@ -442,14 +442,14 @@ class TestSavingDataPackages(object):
 
     def test_adds_resources_inside_data_subfolder(self, tmpfile):
         resource_path = test_helpers.fixture_path('unicode.txt')
-        metadata = {
+        descriptor = {
             'name': 'proverbs',
             'resources': [
                 {'path': resource_path}
             ]
         }
         schema = {}
-        dp = datapackage.DataPackage(metadata, schema)
+        dp = datapackage.DataPackage(descriptor, schema)
         dp.save(tmpfile)
         with zipfile.ZipFile(tmpfile, 'r') as z:
             filename = [name for name in z.namelist()
@@ -460,14 +460,14 @@ class TestSavingDataPackages(object):
 
     def test_fixes_resources_paths_to_be_relative_to_package(self, tmpfile):
         resource_path = test_helpers.fixture_path('unicode.txt')
-        metadata = {
+        descriptor = {
             'name': 'proverbs',
             'resources': [
                 {'name': 'unicode', 'format': 'txt', 'path': resource_path}
             ]
         }
         schema = {}
-        dp = datapackage.DataPackage(metadata, schema)
+        dp = datapackage.DataPackage(descriptor, schema)
         dp.save(tmpfile)
         with zipfile.ZipFile(tmpfile, 'r') as z:
             json_string = z.read('datapackage.json').decode('utf-8')
@@ -485,14 +485,14 @@ class TestSavingDataPackages(object):
 
     def test_should_raise_validation_error_if_datapackage_is_invalid(self,
                                                                      tmpfile):
-        metadata = {}
+        descriptor = {}
         schema = {
             'properties': {
                 'name': {},
             },
             'required': ['name'],
         }
-        dp = datapackage.DataPackage(metadata, schema)
+        dp = datapackage.DataPackage(descriptor, schema)
         with pytest.raises(datapackage.exceptions.ValidationError):
             dp.save(tmpfile)
 
@@ -526,13 +526,13 @@ class TestSavingDataPackages(object):
 class TestImportingDataPackageFromZip(object):
     def test_it_works_with_local_paths(self, datapackage_zip):
         dp = datapackage.DataPackage(datapackage_zip.name)
-        assert dp.metadata['name'] == 'proverbs'
+        assert dp.descriptor['name'] == 'proverbs'
         assert len(dp.resources) == 1
         assert dp.resources[0].data == b'foo\n'
 
     def test_it_works_with_file_objects(self, datapackage_zip):
         dp = datapackage.DataPackage(datapackage_zip)
-        assert dp.metadata['name'] == 'proverbs'
+        assert dp.descriptor['name'] == 'proverbs'
         assert len(dp.resources) == 1
         assert dp.resources[0].data == b'foo\n'
 
@@ -545,7 +545,7 @@ class TestImportingDataPackageFromZip(object):
                                content_type='application/zip')
 
         dp = datapackage.DataPackage(url)
-        assert dp.metadata['name'] == 'proverbs'
+        assert dp.descriptor['name'] == 'proverbs'
         assert len(dp.resources) == 1
         assert dp.resources[0].data == b'foo\n'
 
@@ -570,13 +570,13 @@ class TestImportingDataPackageFromZip(object):
                 assert local_data_file.read() == data_file.read()
 
     def test_it_can_load_from_zip_files_inner_folders(self, tmpfile):
-        metadata = {
+        descriptor = {
             'name': 'foo',
         }
         with zipfile.ZipFile(tmpfile.name, 'w') as z:
-            z.writestr('foo/datapackage.json', json.dumps(metadata))
+            z.writestr('foo/datapackage.json', json.dumps(descriptor))
         dp = datapackage.DataPackage(tmpfile.name, {})
-        assert dp.metadata == metadata
+        assert dp.descriptor == descriptor
 
     def test_it_breaks_if_theres_no_datapackage_json(self, tmpfile):
         with zipfile.ZipFile(tmpfile.name, 'w') as z:
@@ -585,51 +585,51 @@ class TestImportingDataPackageFromZip(object):
             datapackage.DataPackage(tmpfile.name, {})
 
     def test_it_breaks_if_theres_more_than_one_datapackage_json(self, tmpfile):
-        metadata_foo = {
+        descriptor_foo = {
             'name': 'foo',
         }
-        metadata_bar = {
+        descriptor_bar = {
             'name': 'bar',
         }
         with zipfile.ZipFile(tmpfile.name, 'w') as z:
-            z.writestr('foo/datapackage.json', json.dumps(metadata_foo))
-            z.writestr('bar/datapackage.json', json.dumps(metadata_bar))
+            z.writestr('foo/datapackage.json', json.dumps(descriptor_foo))
+            z.writestr('bar/datapackage.json', json.dumps(descriptor_bar))
         with pytest.raises(datapackage.exceptions.DataPackageException):
             datapackage.DataPackage(tmpfile.name, {})
 
 
 class TestSafeDataPackage(object):
     def test_without_resources_is_safe(self):
-        metadata = {}
-        dp = datapackage.DataPackage(metadata, {})
+        descriptor = {}
+        dp = datapackage.DataPackage(descriptor, {})
         assert dp.safe()
 
     def test_with_local_resources_with_inexistent_path_isnt_safe(self):
-        metadata = {
+        descriptor = {
             'resources': [
                 {'path': '/foo/bar'},
             ]
         }
-        dp = datapackage.DataPackage(metadata, {})
+        dp = datapackage.DataPackage(descriptor, {})
         assert not dp.safe()
 
     def test_with_local_resources_with_existent_path_isnt_safe(self):
-        metadata = {
+        descriptor = {
             'resources': [
                 {'path': test_helpers.fixture_path('foo.txt')},
             ]
         }
-        dp = datapackage.DataPackage(metadata, {})
+        dp = datapackage.DataPackage(descriptor, {})
         assert not dp.safe()
 
-    def test_metadata_dict_without_local_resources_is_safe(self):
-        metadata = {
+    def test_descriptor_dict_without_local_resources_is_safe(self):
+        descriptor = {
             'resources': [
                 {'data': 42},
                 {'url': 'http://someplace.com/data.csv'},
             ]
         }
-        dp = datapackage.DataPackage(metadata, {})
+        dp = datapackage.DataPackage(descriptor, {})
         assert dp.safe()
 
     def test_local_with_relative_resources_paths_is_safe(self):
@@ -639,12 +639,12 @@ class TestSafeDataPackage(object):
         assert dp.safe()
 
     def test_local_with_resources_outside_base_path_isnt_safe(self, tmpfile):
-        metadata = {
+        descriptor = {
             'resources': [
                 {'path': __file__},
             ]
         }
-        tmpfile.write(json.dumps(metadata).encode('utf-8'))
+        tmpfile.write(json.dumps(descriptor).encode('utf-8'))
         tmpfile.flush()
         dp = datapackage.DataPackage(tmpfile.name, {})
         assert not dp.safe()
@@ -654,25 +654,25 @@ class TestSafeDataPackage(object):
         assert dp.safe()
 
     def test_zip_with_resources_outside_base_path_isnt_safe(self, tmpfile):
-        metadata = {
+        descriptor = {
             'resources': [
                 {'path': __file__},
             ]
         }
         with zipfile.ZipFile(tmpfile.name, 'w') as z:
-            z.writestr('datapackage.json', json.dumps(metadata))
+            z.writestr('datapackage.json', json.dumps(descriptor))
         dp = datapackage.DataPackage(tmpfile.name, {})
         assert not dp.safe()
 
 
 @pytest.fixture
 def datapackage_zip(tmpfile):
-    metadata = {
+    descriptor = {
         'name': 'proverbs',
         'resources': [
             {'path': test_helpers.fixture_path('foo.txt')},
         ]
     }
-    dp = datapackage.DataPackage(metadata)
+    dp = datapackage.DataPackage(descriptor)
     dp.save(tmpfile)
     return tmpfile

--- a/tests/test_pushpull.py
+++ b/tests/test_pushpull.py
@@ -57,7 +57,7 @@ def test_pull_datapackage(storage, descriptor):
 
     # Assert pulled datapackage
     dp = DataPackage(descriptor)
-    assert dp.metadata == {'name': 'name', 'resources': [
+    assert dp.descriptor == {'name': 'name', 'resources': [
         {'path': 'data.csv', 'name': 'data', 'schema':
             {'fields': [
                 {'name': 'id', 'type': 'integer'},

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -16,7 +16,7 @@ TabularResource = datapackage.resource.TabularResource
 
 
 class TestResource(object):
-    def test_metadata_are_available(self):
+    def test_descriptor_are_available(self):
         resource_dict = {
             'name': 'foo',
             'url': 'http://someplace.com/foo.json',
@@ -24,13 +24,13 @@ class TestResource(object):
             'data': {'foo': 'bar'},
         }
         resource = datapackage.Resource(resource_dict)
-        assert resource.metadata == resource_dict
+        assert resource.descriptor == resource_dict
 
-    def test_metadata_cant_be_assigned(self):
+    def test_descriptor_cant_be_assigned(self):
         resource_dict = {}
         resource = datapackage.Resource(resource_dict)
         with pytest.raises(AttributeError):
-            resource.metadata = {}
+            resource.descriptor = {}
 
     def test_data_is_none_by_default(self):
         resource_dict = {}
@@ -210,7 +210,7 @@ class TestResource(object):
             'path': original_path
         }
         resource = datapackage.Resource.load(resource_dict)
-        resource.metadata['path'] = new_path
+        resource.descriptor['path'] = new_path
         assert resource.data == b'foo\n'
 
     @httpretty.activate
@@ -226,7 +226,7 @@ class TestResource(object):
             'url': original_url
         }
         resource = datapackage.Resource.load(resource_dict)
-        resource.metadata['url'] = new_url
+        resource.descriptor['url'] = new_url
         assert resource.data == b'bar'
 
     def test_can_change_the_data_after_creation(self):
@@ -234,7 +234,7 @@ class TestResource(object):
             'data': ['foo']
         }
         resource = datapackage.Resource.load(resource_dict)
-        resource.metadata['data'] = ['bar']
+        resource.descriptor['data'] = ['bar']
         assert resource.data == ['bar']
 
     def test_local_data_path_returns_the_unmodified_path(self):


### PR DESCRIPTION
Fixes #88.

@vitorbaptista @roll @amercader @akariv for review.