### PR TITLE
nullify local_data_path of relative source in remote package

### DIFF
--- a/datapackage/resource.py
+++ b/datapackage/resource.py
@@ -90,7 +90,7 @@ class Resource(object):
         '''str: The absolute local path for the data if it exists.'''
         path = self._absolute_path(self.descriptor.get('path'))
         if path and not _is_url(path):
-                return os.path.abspath(path)
+            return os.path.abspath(path)
 
     @property
     def remote_data_path(self):

--- a/datapackage/resource.py
+++ b/datapackage/resource.py
@@ -87,7 +87,7 @@ class Resource(object):
 
     @property
     def local_data_path(self):
-        '''str: The absolute local path for the data.'''
+        '''str: The absolute local path for the data if it exists.'''
         path = self._absolute_path(self.descriptor.get('path'))
         if path and not _is_url(path):
                 return os.path.abspath(path)

--- a/datapackage/resource.py
+++ b/datapackage/resource.py
@@ -89,8 +89,7 @@ class Resource(object):
     def local_data_path(self):
         '''str: The absolute local path for the data.'''
         path = self._absolute_path(self.descriptor.get('path'))
-        if path:
-            if not _is_url(path):
+        if path and not _is_url(path):
                 return os.path.abspath(path)
 
     @property

--- a/datapackage/resource.py
+++ b/datapackage/resource.py
@@ -90,7 +90,8 @@ class Resource(object):
         '''str: The absolute local path for the data.'''
         path = self._absolute_path(self.descriptor.get('path'))
         if path:
-            return os.path.abspath(path)
+            if not _is_url(path):
+                return os.path.abspath(path)
 
     @property
     def remote_data_path(self):

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -346,26 +346,6 @@ class TestDataPackageResources(object):
             datapackage.DataPackage(descriptor).resources[0].data
 
     @httpretty.activate
-    def test_if_relative_resource_of_remote_package_has_absolute_path(self):
-        url = 'http://someplace.com/datapackage.json'
-
-        package = '''{
-            "resources": [
-                {"path": "data.csv"}
-            ]
-        }'''
-
-        httpretty.register_uri(httpretty.GET, url,
-            body=package,
-            content_type='application/json')
-
-        dp = datapackage.DataPackage(url)
-
-        local_data_path = dp.resources[0].local_data_path
-        if local_data_path:
-            assert not local_data_path.startswith('/')
-
-    @httpretty.activate
     def test_remote_resource_has_no_local_data_path(self):
         url = 'http://someplace.com/datapackage.json'
 

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -345,6 +345,44 @@ class TestDataPackageResources(object):
         with pytest.raises(IOError):
             datapackage.DataPackage(descriptor).resources[0].data
 
+    @httpretty.activate
+    def test_if_relative_resource_of_remote_package_has_absolute_path(self):
+        url = 'http://someplace.com/datapackage.json'
+
+        package = """{
+            "resources": [
+                {"path": "data.csv"}
+            ]
+        }"""
+
+        httpretty.register_uri(httpretty.GET, url,
+            body=package,
+            content_type='application/json')
+
+        dp = datapackage.DataPackage(url)
+
+        local_data_path = dp.resources[0].local_data_path
+        if local_data_path:
+            assert not local_data_path.startswith('/')
+
+    @httpretty.activate
+    def test_if_resource_of_remote_package_has_local_data_path(self):
+        url = 'http://someplace.com/datapackage.json'
+
+        package = """{
+                    "resources": [
+                        {"path": "data.csv"}
+                    ]
+                }"""
+
+        httpretty.register_uri(httpretty.GET, url,
+                               body=package,
+                               content_type='application/json')
+
+        dp = datapackage.DataPackage(url)
+
+        assert dp.resources[0].local_data_path == None
+
     def test_changing_resource_descriptor_changes_it_in_the_datapackage(self):
         descriptor = {
             'resources': [

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -349,11 +349,11 @@ class TestDataPackageResources(object):
     def test_if_relative_resource_of_remote_package_has_absolute_path(self):
         url = 'http://someplace.com/datapackage.json'
 
-        package = """{
+        package = '''{
             "resources": [
                 {"path": "data.csv"}
             ]
-        }"""
+        }'''
 
         httpretty.register_uri(httpretty.GET, url,
             body=package,
@@ -369,11 +369,11 @@ class TestDataPackageResources(object):
     def test_if_resource_of_remote_package_has_local_data_path(self):
         url = 'http://someplace.com/datapackage.json'
 
-        package = """{
+        package = '''{
                     "resources": [
                         {"path": "data.csv"}
                     ]
-                }"""
+                }'''
 
         httpretty.register_uri(httpretty.GET, url,
                                body=package,

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -381,7 +381,7 @@ class TestDataPackageResources(object):
 
         dp = datapackage.DataPackage(url)
 
-        assert dp.resources[0].local_data_path == None
+        assert dp.resources[0].local_data_path is None
 
     def test_changing_resource_descriptor_changes_it_in_the_datapackage(self):
         descriptor = {

--- a/tests/test_datapackage.py
+++ b/tests/test_datapackage.py
@@ -366,7 +366,7 @@ class TestDataPackageResources(object):
             assert not local_data_path.startswith('/')
 
     @httpretty.activate
-    def test_if_resource_of_remote_package_has_local_data_path(self):
+    def test_remote_resource_has_no_local_data_path(self):
         url = 'http://someplace.com/datapackage.json'
 
         package = '''{


### PR DESCRIPTION
This fixes #97 by setting the `local_data_path` of a relative source in a remote package to `None`.