### PR TITLE
added gyear and gyearmonth types to type enum for validation, per spec

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,3 +10,4 @@ Luiz Armesto <luiz.armesto@gmail.com>
 hansl <hansl@edge-net.net>
 femtotrader <femto.trader@gmail.com>
 Vitor Baptista <vitor@vitorbaptista.com>
+Bryon Jacob <bryon@data.world>

--- a/datapackage/schemas/definitions.json
+++ b/datapackage/schemas/definitions.json
@@ -45,6 +45,8 @@
                         "duration",
                         "geopoint",
                         "geojson",
+                        "gyear",
+                        "gyearmonth",
                         "any"
                       ],
                       "propertyOrder": 40

--- a/datapackage/schemas/json-table-schema.json
+++ b/datapackage/schemas/json-table-schema.json
@@ -26,6 +26,8 @@
               "object",
               "geopoint",
               "geojson",
+              "gyear",
+              "gyearmonth",
               "array",
               "any"
             ]


### PR DESCRIPTION
Hey all - per the most recent change to the spec noted at http://specs.frictionlessdata.io/json-table-schema/ , `gyear` and `gyearmonth` should be valid types for datapackage validation - this PR adds both of those types to the schema file.  