### PR TITLE
Apply defaults to data package descriptor

### DIFF
--- a/datapackage/config.py
+++ b/datapackage/config.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+# Module API
+
+DEFAULT_PACKAGE_PROFILE = 'data-package'
+DEFAULT_RESOURCE_PROFILE = 'data-resource'
+DEFAULT_RESOURCE_ENCODING = 'utf-8'
+DEFAULT_FIELD_TYPE = 'string'
+DEFAULT_FIELD_FORMAT = 'default'
+DEFAULT_MISSING_VALUES = ['']
+DEFAULT_DIALECT = {
+    'delimiter': ',',
+    'doubleQuote': True,
+    'lineTerminator': '\r\n',
+    'quoteChar': '""',
+    'escapeChar': '\\',
+    'skipInitialSpace': True,
+    'header': True,
+    'caseSensitiveHeader': False,
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,13 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import mock
 import pytest
 import tempfile
+from datapackage import DataPackage
 
+
+# Fixtures
 
 @pytest.yield_fixture()
 def tmpfile():
@@ -24,3 +28,10 @@ def txt_tmpfile():
 def csv_tmpfile():
     with tempfile.NamedTemporaryFile(suffix='.csv') as f:
         yield f
+
+
+@pytest.yield_fixture()
+def NoDefaultsDataPackage():
+    class NoDefaultsDataPackage(DataPackage):
+        _apply_defaults = mock.Mock()
+    yield NoDefaultsDataPackage

--- a/tests/test_pushpull.py
+++ b/tests/test_pushpull.py
@@ -41,7 +41,8 @@ def test_push_datapackage(storage):
     ]
 
 
-def test_pull_datapackage(storage, descriptor):
+@mock.patch.object(DataPackage, '_apply_defaults')
+def test_pull_datapackage(_apply_defaults, storage, descriptor):
 
     # Prepare and call
     storage.buckets = ['data___data']


### PR DESCRIPTION
- connects #131
  - apply defaults (profile, resource.profile, resource.encoding, resource.dialect, resource.schema)

---

For now I don't use automated method from `jsonschema` package for `tableschema` and `datapackage` - http://python-jsonschema.readthedocs.io/en/latest/faq/#why-doesn-t-my-schema-that-has-a-default-property-actually-set-the-default-on-my-instance

There are reasons:
- solution seems over-complicated (modifying validation etc)
- not sure is it portable even to javascript (don't want too have two different kind of logic)
- jsonschema still doesn't cover some edge-cases like default field type

So for now solution is pretty simple. Leaving for a future re-estimation jsonschema usage actuality.