### PR TITLE
Remove escapeChar from DEFAULT_DIALECT

### DIFF
--- a/datapackage/config.py
+++ b/datapackage/config.py
@@ -19,7 +19,6 @@ DEFAULT_DIALECT = {
     'doubleQuote': True,
     'lineTerminator': '\r\n',
     'quoteChar': '"',
-    'escapeChar': '\\',
     'skipInitialSpace': True,
     'header': True,
     'caseSensitiveHeader': False,

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -300,7 +300,6 @@ def test_descriptor_apply_defaults_resource_tabular_dialect():
                 'doubleQuote': True,
                 'lineTerminator': '\r\n',
                 'quoteChar': '"',
-                'escapeChar': '\\',
                 'skipInitialSpace': True,
                 'header': True,
                 'caseSensitiveHeader': False,

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -226,7 +226,6 @@ def test_descriptor_expand_tabular_dialect():
             'doubleQuote': True,
             'lineTerminator': '\r\n',
             'quoteChar': '"',
-            'escapeChar': '\\',
             'skipInitialSpace': True,
             'header': True,
             'caseSensitiveHeader': False,


### PR DESCRIPTION
According to the [CSV dialect specification](https://frictionlessdata.io/specs/csv-dialect/), the escapeChar option should not be set by default.

> `escapeChar` - specifies a one-character string to use for escaping (for example, `\`), mutually exclusive with `quoteChar`. Not set by default

Closes #200
Continued from #201 