### PR TITLE
Fix save order for Package save method

### DIFF
--- a/datapackage/package.py
+++ b/datapackage/package.py
@@ -220,19 +220,8 @@ class Package(object):
         """https://github.com/frictionlessdata/datapackage-py#package
         """
 
-        # Save descriptor to json
-        if str(target).endswith('.json'):
-            mode = 'w'
-            encoding = 'utf-8'
-            if six.PY2:
-                mode = 'wb'
-                encoding = None
-            helpers.ensure_dir(target)
-            with io.open(target, mode=mode, encoding=encoding) as file:
-                json.dump(self.__current_descriptor, file, indent=4)
-
         # Save package to storage
-        elif storage is not None:
+        if storage is not None:
             if not isinstance(storage, Storage):
                 storage = Storage.connect(storage, **options)
             buckets = []
@@ -247,6 +236,17 @@ class Package(object):
             for bucket in storage.buckets:
                 resource = self.resources[buckets.index(bucket)]
                 storage.write(bucket, resource.iter())
+
+        # Save descriptor to json
+        elif str(target).endswith('.json'):
+            mode = 'w'
+            encoding = 'utf-8'
+            if six.PY2:
+                mode = 'wb'
+                encoding = None
+            helpers.ensure_dir(target)
+            with io.open(target, mode=mode, encoding=encoding) as file:
+                json.dump(self.__current_descriptor, file, indent=4)
 
         # Save package to zip
         else:


### PR DESCRIPTION
According to the [documentation](https://github.com/frictionlessdata/datapackage-py#packagesavetarget-storagenone-options), save should prioritize saving to storage over
saving to json.

> `package.save(target, storage=None, **options)`
> Saves this data package to storage if storage argument is passed or saves this data package's descriptor to json file if target arguments ends with .json or saves this data package to zip file otherwise.

Proritizing saving to storage over saving to json is also consistent with the behaviour of the resource save method.