### PR TITLE
Enable passing options from resource init to get_table

### DIFF
--- a/datapackage/resource.py
+++ b/datapackage/resource.py
@@ -62,6 +62,7 @@ class Resource(object):
         self.__strict = strict
         self.__table = None
         self.__errors = []
+        self.__table_options = options
 
         # Build resource
         self.__build()
@@ -352,7 +353,7 @@ class Resource(object):
 
             # General resource
             else:
-                options = {}
+                options = self.__table_options
                 descriptor = self.__current_descriptor
                 options['format'] = descriptor.get('format', 'csv')
                 if descriptor.get('data'):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -529,6 +529,23 @@ def test_descriptor_table_tabular_dialect_header_false():
         {'id': 2, 'name': '中国人'},
     ]
 
+# Resource table options
+def test_resource_table_options(patch_get):
+    descriptor = {
+        'name': 'name',
+        'profile': 'tabular-data-resource',
+        'path': ['http://example.com/resource_data.csv'],
+        'schema': 'resource_schema.json',
+    }
+    # Mocks
+    patch_get('http://example.com/resource_data.csv', body="\n\nid,name\n1,english\n2,中国人")
+    # Tests
+    resource = Resource(descriptor, base_path='data', headers=3)
+    assert resource.table.read(keyed=True) == [
+        {'id': 1, 'name': 'english'},
+        {'id': 2, 'name': '中国人'},
+    ]
+
 
 # Resource.raw_iter/read
 


### PR DESCRIPTION
Very similar to the way that these options are passed to the `Storage.connect` method,
we now use these options in the `Table` constructor in cases where storage is not used.