### PR TITLE
Allows skip_rows to be provided in Resource options as well

### DIFF
--- a/datapackage/resource.py
+++ b/datapackage/resource.py
@@ -360,7 +360,8 @@ class Resource(object):
                     options['format'] = 'inline'
                 if descriptor.get('encoding'):
                     options['encoding'] = descriptor['encoding']
-                options['skip_rows'] = descriptor.get('skipRows', [])
+                options['skip_rows'] = descriptor.get('skipRows',
+                                                      options.get('skip_rows', []))
                 dialect = descriptor.get('dialect')
                 if dialect:
                     if not dialect.get('header', config.DEFAULT_DIALECT['header']):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -495,6 +495,19 @@ def test_descriptor_table_tabular_skip_rows():
     ]
 
 
+def test_resource_options_skip_rows():
+    descriptor = {
+        'name': 'name',
+        'profile': 'tabular-data-resource',
+        'path': ['resource_data.csv'],
+        'schema': 'resource_schema.json',
+    }
+    resource = Resource(descriptor, base_path='data', skip_rows=[2])
+    assert resource.table.read(keyed=True) == [
+        {'id': 2, 'name': '中国人'},
+    ]
+
+
 def test_descriptor_table_tabular_dialect_custom():
     descriptor = {
         'name': 'name',


### PR DESCRIPTION
Resource constructor allows passing options directly to tabulator - however, 'skip_rows' was overwritten by a value from the descriptor.
This change will check for another fallback value, from the provided options.