### PR TITLE
Allow empty files, handle 'None' encoding

### DIFF
--- a/datapackage/resource.py
+++ b/datapackage/resource.py
@@ -253,7 +253,11 @@ class Resource(object):
                     for chunk in stream:
                         contents += chunk
                         if len(contents) > 1000: break
-                encoding = cchardet.detect(contents)['encoding'].lower()
+                encoding = cchardet.detect(contents)['encoding']
+                if encoding is None:
+                    encoding = 'utf-8'
+                else:
+                    encoding = encoding.lower()
                 descriptor['encoding'] = 'utf-8' if encoding == 'ascii' else encoding
 
         # Schema

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -29,3 +29,7 @@ def test_infer():
 def test_infer_non_utf8_file():
     descriptor = infer('data/data_with_accents.csv')
     assert descriptor['resources'][0]['encoding'] == 'iso-8859-1'
+
+def test_infer_empty_file():
+    descriptor = infer('data/empty.csv')
+    assert descriptor['resources'][0].get('encoding') == 'utf-8'


### PR DESCRIPTION
cchardet might return None as the encoding (could happen for empty files and possible other edge cases).