### PR TITLE
Require tableschema>=1.12.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ INSTALL_REQUIRES = [
     'jsonschema>=2.5',
     'unicodecsv>=0.14',
     'jsonpointer>=1.10',
-    'tableschema>=1.10',
+    'tableschema>=1.12.1',
     'tabulator>=1.29',
 ]
 TESTS_REQUIRE = [


### PR DESCRIPTION
# Overview

Hi. I tried to upgrade to datapackage 1.10.1 but found it is not compatible with Tableschema 1.12.0.

Steps to reproduce:

```
$ pip install datapackage==1.10.1
$ pip install tableschema==1.12.0
$ python3
>>> import datapackage
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/chris/.virtualenvs/datapackage-repro-gwcs1gD0/lib/python3.6/site-packages/datapackage/__init__.py", line 13, in <module>
    from .package import Package
  File "/home/chris/.virtualenvs/datapackage-repro-gwcs1gD0/lib/python3.6/site-packages/datapackage/package.py", line 20, in <module>
    from .resource import Resource
  File "/home/chris/.virtualenvs/datapackage-repro-gwcs1gD0/lib/python3.6/site-packages/datapackage/resource.py", line 17, in <module>
    from .profile import Profile
  File "/home/chris/.virtualenvs/datapackage-repro-gwcs1gD0/lib/python3.6/site-packages/datapackage/profile.py", line 13, in <module>
    import datapackage.registry
  File "/home/chris/.virtualenvs/datapackage-repro-gwcs1gD0/lib/python3.6/site-packages/datapackage/registry.py", line 11, in <module>
    from .exceptions import RegistryError
  File "/home/chris/.virtualenvs/datapackage-repro-gwcs1gD0/lib/python3.6/site-packages/datapackage/exceptions.py", line 11, in <module>
    DataPackageException = tableschema.DataPackageException
AttributeError: module 'tableschema' has no attribute 'DataPackageException'
```

This PR bumps the version requirement in `setup.py` to ensure a compatible version is installed, but maybe there is another issue to be raised on the tableschema repo because a non-backwards-compatible change was introduced in a patch release?

Cheers

---

Please preserve this line to notify @roll (lead of this repository)
