### PR TITLE
use iterator for streams in multipart fixes #246

### DIFF
--- a/datapackage/resource.py
+++ b/datapackage/resource.py
@@ -907,9 +907,9 @@ class _MultipartSource(object):
     def __iter_rows(self):
         streams = []
         if self.__remote:
-            streams = [urlopen(chunk) for chunk in self.__source]
+            streams = (urlopen(chunk) for chunk in self.__source)
         else:
-            streams = [io.open(chunk, 'rb') for chunk in self.__source]
+            streams = (io.open(chunk, 'rb') for chunk in self.__source)
         for stream in streams:
             for row in stream:
                 if not row.endswith(b'\n'):


### PR DESCRIPTION
# Overview

Very simple update to avoid opening  at once all streams of a multipart resource which is unnecessary and causes system issues for large number of chunks.
relates #276 
---

Please preserve this line to notify @roll (lead of this repository)
